### PR TITLE
Add Statamic CMS v4 as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "statamic-addon",
     "require": {
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "statamic/cms": "^4.0"
+        "statamic/cms": "^3.1 || ^4.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "statamic-addon",
     "require": {
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "statamic/cms": "^3.1"
+        "statamic/cms": "^4.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This fixes #30 .
It enables usage of Placid on a Statamic v4 installation.